### PR TITLE
[FEATURE] 헤더 모바일 환경 고려 컴포넌트 추가

### DIFF
--- a/frontend/src/components/header/HeaderNav.tsx
+++ b/frontend/src/components/header/HeaderNav.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { cn } from '@/shared/cn';
 import { textStyles } from '@/styles/typography';
 import type { SubTabsMap } from './types';
@@ -11,6 +12,33 @@ type Props = {
   onNavigate: (path: string) => void;
 };
 
+function HamburgerIcon({ open }: { open: boolean }) {
+  return (
+    <svg
+      width="22"
+      height="22"
+      viewBox="0 0 22 22"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    >
+      {open ? (
+        <>
+          <line x1="4" y1="4" x2="18" y2="18" />
+          <line x1="18" y1="4" x2="4" y2="18" />
+        </>
+      ) : (
+        <>
+          <line x1="3" y1="6" x2="19" y2="6" />
+          <line x1="3" y1="11" x2="19" y2="11" />
+          <line x1="3" y1="16" x2="19" y2="16" />
+        </>
+      )}
+    </svg>
+  );
+}
+
 export default function HeaderNav({
   mainTabs,
   subTabsMap,
@@ -19,14 +47,21 @@ export default function HeaderNav({
   pathname,
   onNavigate,
 }: Props) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const [mobileExpanded, setMobileExpanded] = useState<string | null>(null);
+
   const subTabs = openMain ? subTabsMap[openMain] : undefined;
 
+  const handleMobileNavigate = (path: string) => {
+    onNavigate(path);
+    setMobileOpen(false);
+    setMobileExpanded(null);
+  };
+
   return (
-    <div
-      className="w-full xl:px-72 bg-primary relative"
-      onMouseLeave={() => onOpenMain(null)}
-    >
-      <div className="w-full flex items-center justify-center space-x-3">
+    <div className="w-full bg-primary relative" onMouseLeave={() => onOpenMain(null)}>
+      {/* 데스크탑 네비게이션 */}
+      <div className="hidden md:flex xl:px-72 w-full items-center justify-center space-x-3">
         {mainTabs.map((tab) => (
           <button
             key={tab}
@@ -44,8 +79,9 @@ export default function HeaderNav({
         ))}
       </div>
 
+      {/* 데스크탑 드롭다운 */}
       {openMain && subTabs && (
-        <div className="absolute left-0 top-full w-full bg-surface shadow-md z-20 border-b border-border">
+        <div className="hidden md:block absolute left-0 top-full w-full bg-surface shadow-md z-20 border-b border-border">
           <div className="mx-auto w-full max-w-6xl px-8 py-6">
             <h3
               className={cn(
@@ -55,11 +91,9 @@ export default function HeaderNav({
             >
               {openMain}
             </h3>
-
             <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-x-6 gap-y-2">
               {subTabs.map((sub) => {
                 const isActive = pathname.startsWith(sub.path);
-
                 return (
                   <button
                     key={sub.path}
@@ -81,6 +115,79 @@ export default function HeaderNav({
               })}
             </div>
           </div>
+        </div>
+      )}
+
+      {/* 모바일 상단 바 */}
+      <div className="md:hidden flex items-center justify-between px-4 py-3">
+        <span className={cn(textStyles.uiLg, 'text-primary-fg')}>메뉴</span>
+        <button
+          onClick={() => setMobileOpen((v) => !v)}
+          className="text-primary-fg p-1"
+          aria-label={mobileOpen ? '메뉴 닫기' : '메뉴 열기'}
+        >
+          <HamburgerIcon open={mobileOpen} />
+        </button>
+      </div>
+
+      {/* 모바일 드롭다운 메뉴 */}
+      {mobileOpen && (
+        <div className="md:hidden absolute left-0 top-full w-full bg-surface shadow-md z-20 border-b border-border">
+          {mainTabs.map((tab) => {
+            const isExpanded = mobileExpanded === tab;
+            const subs = subTabsMap[tab];
+            return (
+              <div key={tab} className="border-b border-border last:border-b-0">
+                <button
+                  onClick={() =>
+                    setMobileExpanded(isExpanded ? null : tab)
+                  }
+                  className={cn(
+                    'w-full flex items-center justify-between px-5 py-4 transition',
+                    textStyles.uiLg,
+                    isExpanded ? 'text-primary bg-primary-50' : 'text-fg hover:bg-muted',
+                  )}
+                >
+                  <span>{tab}</span>
+                  <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    className={cn('transition-transform', isExpanded && 'rotate-180')}
+                  >
+                    <polyline points="3,5 8,11 13,5" />
+                  </svg>
+                </button>
+
+                {isExpanded && subs && (
+                  <div className="bg-muted px-4 py-2">
+                    {subs.map((sub) => {
+                      const isActive = pathname.startsWith(sub.path);
+                      return (
+                        <button
+                          key={sub.path}
+                          onClick={() => handleMobileNavigate(sub.path)}
+                          className={cn(
+                            'w-full text-left px-4 py-3 rounded-md transition',
+                            textStyles.bodyMd,
+                            isActive
+                              ? 'text-primary font-semibold'
+                              : 'text-muted-fg hover:text-fg',
+                          )}
+                        >
+                          {sub.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## ✨ 기능 개요
모바일 환경 고려 헤더 컴포넌트 구현

## ✅ 주요 작업 내역
- [x] 모바일 환경 고려 헤더 컴포넌트 구현

## 📌 기타 참고 사항
전
<img width="480" alt="image" src="https://github.com/user-attachments/assets/c609ac78-3043-47c8-8934-55aad85c3dac" />

후
<img width="480" height="598" alt="image" src="https://github.com/user-attachments/assets/43a53668-72ca-4fd0-98d0-0fc0e53bbab5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 모바일에서 햄버거 메뉴 아이콘으로 네비게이션을 토글할 수 있습니다.
  * 메뉴 아이콘이 열린/닫힌 상태에 따라 시각적으로 변화합니다.
  * 모바일 메뉴의 항목을 탭하여 하위 메뉴를 확장 및 축소할 수 있습니다.
  * 하위 메뉴 항목 선택 시 드롭다운이 자동으로 닫힙니다.

* **개선 사항**
  * 데스크톱과 모바일 환경에 각각 최적화된 반응형 레이아웃입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->